### PR TITLE
Remove build number from version number

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,7 @@
     <groupId>jakarta.el</groupId>
     <artifactId>jakarta.el-api</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.1-b07-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <name>Expression Language 3.0 API</name>
 
     <properties>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish</groupId>
     <artifactId>javax.el.impl</artifactId>
-    <version>3.0.1-b11-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Expression Language 3.0 Implementation</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish</groupId>
     <artifactId>javax.el</artifactId>
-    <version>3.0.1-b11-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Expression Language 3.0</name>
 


### PR DESCRIPTION
Version number also contains build number, which deviates from the standard being followed for other Jakarta EE projects. Standardising build number will also help with release pipeline for this project.