### PR TITLE
Increment version to 3.0.2

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,7 @@
     <groupId>jakarta.el</groupId>
     <artifactId>jakarta.el-api</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.2-SNAPSHOT</version>
     <name>Expression Language 3.0 API</name>
 
     <properties>


### PR DESCRIPTION
There is a 3.0.1 release on Maven Central:
https://search.maven.org/artifact/javax.el/javax.el-api/3.0.1-b06/jar
Therefore, increment to next patch release for EE4J_8 release

Signed-off-by: Mark Thomas <markt@apache.org>