### PR TITLE
Fix broken EE4J_8 branch plus clean-up

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -196,6 +196,7 @@
                     <arguments>${release.arguments}</arguments>
                 </configuration>
             </plugin>
+        </plugins>
                     
         <resources>
             <resource>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -31,7 +31,7 @@
     <groupId>jakarta.el</groupId>
     <artifactId>jakarta.el-api</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.2-SNAPSHOT</version>
     <name>Expression Language 3.0 API</name>
 
     <properties>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 1997, 2018 Oracle and/or its affiliates and others.
-     All rights reserved.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -197,7 +197,7 @@
                 </configuration>
             </plugin>
         </plugins>
-                    
+
         <resources>
             <resource>
                 <directory>src/main/java</directory>


### PR DESCRIPTION
We need to re-run the 3.0.2 release. The EE4J_8 branch is currently broken. This PR fixes that, sets the version number to 3.0.2 (as previously discussed) and fixes some white-space diffs between this branch and master to keep the diff to a minimum.