### PR TITLE
[JBEE-249] Catch the NoClassDefFoundError and add to the notAClass co…

### DIFF
--- a/api/src/main/java/javax/el/ImportHandler.java
+++ b/api/src/main/java/javax/el/ImportHandler.java
@@ -153,7 +153,12 @@ public class ImportHandler {
         if (!notAClass.contains(className)) {
             try {
                 return Class.forName(className, false, Thread.currentThread().getContextClassLoader());
-            } catch (ClassNotFoundException ex) {
+                // Some operating systems have case-insensitive path names. An example is Windows if className is
+                // attempting to be resolved from a wildcard import a java.lang.NoClassDefFoundError may be thrown as
+                // the expected case for the type likely doesn't match. See 
+                // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8024775 and 
+                // https://bugs.openjdk.java.net/browse/JDK-8133522.
+            } catch (ClassNotFoundException | NoClassDefFoundError ex) {
                 notAClass.add(className);
             }
         }


### PR DESCRIPTION
…llection for cases where the OS may have case-insensitive paths.

Signed-off-by: James Perkins <jperkins@redhat.com>

This came up on https://issues.jboss.org/browse/JBEE-249 and seems to affect Windows only with wildcard imports. I've not been able to test this on this default implementation, but it seems it could be an issue here so we thought an upstream fix would be good. Please let me know if further details are need.

Reproducing on Windows is quite easy with a JSP. 