### PR TITLE
Update copyright dates after javax -> jakarta rename

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates and others.
+    Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
     All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/el/ArrayELResolver.java
+++ b/api/src/main/java/jakarta/el/ArrayELResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/BeanELResolver.java
+++ b/api/src/main/java/jakarta/el/BeanELResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/BeanNameELResolver.java
+++ b/api/src/main/java/jakarta/el/BeanNameELResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/el/BeanNameResolver.java
+++ b/api/src/main/java/jakarta/el/BeanNameResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/el/CompositeELResolver.java
+++ b/api/src/main/java/jakarta/el/CompositeELResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/ELClass.java
+++ b/api/src/main/java/jakarta/el/ELClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2013, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/el/ELContext.java
+++ b/api/src/main/java/jakarta/el/ELContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/ELContextEvent.java
+++ b/api/src/main/java/jakarta/el/ELContextEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/ELContextListener.java
+++ b/api/src/main/java/jakarta/el/ELContextListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/ELException.java
+++ b/api/src/main/java/jakarta/el/ELException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/ELManager.java
+++ b/api/src/main/java/jakarta/el/ELManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2013, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/el/ELProcessor.java
+++ b/api/src/main/java/jakarta/el/ELProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/el/ELResolver.java
+++ b/api/src/main/java/jakarta/el/ELResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/ELUtil.java
+++ b/api/src/main/java/jakarta/el/ELUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/EvaluationListener.java
+++ b/api/src/main/java/jakarta/el/EvaluationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/el/Expression.java
+++ b/api/src/main/java/jakarta/el/Expression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/ExpressionFactory.java
+++ b/api/src/main/java/jakarta/el/ExpressionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/FactoryFinder.java
+++ b/api/src/main/java/jakarta/el/FactoryFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/FunctionMapper.java
+++ b/api/src/main/java/jakarta/el/FunctionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/ImportHandler.java
+++ b/api/src/main/java/jakarta/el/ImportHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/el/LambdaExpression.java
+++ b/api/src/main/java/jakarta/el/LambdaExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/el/ListELResolver.java
+++ b/api/src/main/java/jakarta/el/ListELResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/MapELResolver.java
+++ b/api/src/main/java/jakarta/el/MapELResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/MethodExpression.java
+++ b/api/src/main/java/jakarta/el/MethodExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/MethodInfo.java
+++ b/api/src/main/java/jakarta/el/MethodInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/MethodNotFoundException.java
+++ b/api/src/main/java/jakarta/el/MethodNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/PrivateMessages.properties
+++ b/api/src/main/java/jakarta/el/PrivateMessages.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
 # Copyright 2004 The Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/java/jakarta/el/PropertyNotFoundException.java
+++ b/api/src/main/java/jakarta/el/PropertyNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/PropertyNotWritableException.java
+++ b/api/src/main/java/jakarta/el/PropertyNotWritableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/ResourceBundleELResolver.java
+++ b/api/src/main/java/jakarta/el/ResourceBundleELResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/StandardELContext.java
+++ b/api/src/main/java/jakarta/el/StandardELContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/el/StaticFieldELResolver.java
+++ b/api/src/main/java/jakarta/el/StaticFieldELResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/el/TypeConverter.java
+++ b/api/src/main/java/jakarta/el/TypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/el/ValueExpression.java
+++ b/api/src/main/java/jakarta/el/ValueExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/VariableMapper.java
+++ b/api/src/main/java/jakarta/el/VariableMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/el/package.html
+++ b/api/src/main/java/jakarta/el/package.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
     Copyright 2004 The Apache Software Foundation
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates and others.
+    Copyright (c) 1997, 2019 Oracle and/or its affiliates and others.
     All rights reserved.
 
     This program and the accompanying materials are made available under the


### PR DESCRIPTION
Use Eclipse 2 date format (as per the Eclipse project handbook)
consistently

Signed-off-by: Mark Thomas <markt@apache.org>