### PR TITLE
[issue-114] EL should coerce String to Integer in equals operation

### DIFF
--- a/impl/src/main/java/com/sun/el/lang/ELSupport.java
+++ b/impl/src/main/java/com/sun/el/lang/ELSupport.java
@@ -106,18 +106,6 @@ public class ELSupport {
         if (obj0 == null || obj1 == null) {
             return false;
         }
-        if (obj0 instanceof Boolean || obj1 instanceof Boolean) {
-            return coerceToBoolean(obj0).equals(coerceToBoolean(obj1));
-        }
-        if (obj0.getClass().isEnum()) {
-            return obj0.equals(coerceToEnum(obj1, obj0.getClass()));
-        }
-        if (obj1.getClass().isEnum()) {
-            return obj1.equals(coerceToEnum(obj0, obj1.getClass()));
-        }
-        if (obj0 instanceof String || obj1 instanceof String) {
-            return coerceToString(obj0).equals(coerceToString(obj1));
-        }
         if (isBigDecimalOp(obj0, obj1)) {
             BigDecimal bd0 = (BigDecimal) coerceToNumber(obj0, BigDecimal.class);
             BigDecimal bd1 = (BigDecimal) coerceToNumber(obj1, BigDecimal.class);
@@ -137,9 +125,20 @@ public class ELSupport {
             Long l0 = (Long) coerceToNumber(obj0, Long.class);
             Long l1 = (Long) coerceToNumber(obj1, Long.class);
             return l0.equals(l1);
-        } else {
-            return obj0.equals(obj1);
         }
+        if (obj0 instanceof Boolean || obj1 instanceof Boolean) {
+            return coerceToBoolean(obj0).equals(coerceToBoolean(obj1));
+        }
+        if (obj0.getClass().isEnum()) {
+            return obj0.equals(coerceToEnum(obj1, obj0.getClass()));
+        }
+        if (obj1.getClass().isEnum()) {
+            return obj1.equals(coerceToEnum(obj0, obj1.getClass()));
+        }
+        if (obj0 instanceof String || obj1 instanceof String) {
+            return coerceToString(obj0).equals(coerceToString(obj1));
+        }
+        return obj0.equals(obj1);
     }
 
     /**

--- a/src/test/java/org/glassfish/el/test/OperatorTest.java
+++ b/src/test/java/org/glassfish/el/test/OperatorTest.java
@@ -49,22 +49,14 @@ public class OperatorTest {
     public void setUp() {
     }
     
-    void testExpr(String testname, String expr, Long expected) {
+    void testExpr(String testname, String expr, Object expected) {
         System.out.println("=== Test " + testname + " ===");
         System.out.println(" ** " + expr);
         Object result = elp.eval(expr);
         System.out.println("    returns " + result);
         assertEquals(expected, result);
     }
-    
-    void testExpr(String testname, String expr, String expected) {
-        System.out.println("=== Test " + testname + " ===");
-        System.out.println(" ** " + expr);
-        Object result = elp.eval(expr);
-        System.out.println("    returns " + result);
-        assertEquals(expected, result);
-    }
-    
+
     @Test
     public void testConcat() {
         testExpr("concat", "a = null; b = null; a + b", 0L);
@@ -122,5 +114,14 @@ public class OperatorTest {
                 elm.getELContext(), "${name}", Object.class, new Class[] {});
         m.invoke(elm.getELContext(), null);
         */
+    }
+
+    @Test
+    public void testEquals() {
+        testExpr("string", "'xx' == 'xx'", Boolean.TRUE);
+        testExpr("number", "'a'.length() == 1", Boolean.TRUE);
+        testExpr("coerce '01'", "'01' == 1", Boolean.TRUE);
+        testExpr("coerce '01'", "1 == '01'", Boolean.TRUE);
+        testExpr("coerce '01.10'", "'01.10' == 1.10", Boolean.TRUE);
     }
 }


### PR DESCRIPTION
Fix for issue #114 

I'm just doing more or less the same that @markt-asf did in tomcat (but I decided to not change if-else-if and respect current structure). It just moved the order to follow the spec.

Bug in tomcat: https://bz.apache.org/bugzilla/show_bug.cgi?id=52666
Commit in tomcat: https://github.com/apache/tomcat/commit/bf9bf39bba9933642a9bb57f48871e54bcf67273

@markt-asf @bshannon This change is very simple. Please take a look and comment in the PR if you see anything wrong.

Regards!