### PR TITLE
Backport Fix #136 - ELParser PermGen Memory Leak

### DIFF
--- a/impl/build.xml
+++ b/impl/build.xml
@@ -32,14 +32,6 @@
                 outputdirectory="${dir}"
                 javacchome="${javacc.home}"/>
 
-        <replaceregexp byline="true">
-          <regexp pattern="final private LookaheadSuccess"/>
-          <substitution expression="static final private LookaheadSuccess"/>
-          <fileset dir="src/main/java/com/sun/el/parser">
-            <include name="ELParser.java"/>
-          </fileset>
-        </replaceregexp>
-
     </target>
 </project>
 

--- a/impl/src/main/java/com/sun/el/parser/ELParser.java
+++ b/impl/src/main/java/com/sun/el/parser/ELParser.java
@@ -2862,7 +2862,7 @@ public class ELParser/*@bgen(jjtree)*/implements ELParserTreeConstants, ELParser
   }
 
   static private final class LookaheadSuccess extends java.lang.Error { }
-  static final private LookaheadSuccess jj_ls = new LookaheadSuccess();
+  final private LookaheadSuccess jj_ls = new LookaheadSuccess();
   private boolean jj_scan_token(int kind) {
     if (jj_scanpos == jj_lastpos) {
       jj_la--;


### PR DESCRIPTION
Backport #136 to 3.x version

- Revert commit https://github.com/javaee/uel-ri/commit/d2f0cbf02ba29f28a21f5a1ec78836d1edcafa2c because it could cause a PermGen memory leak