### PR TITLE
NullPointerException when value and targetType is null

### DIFF
--- a/impl/src/main/java/com/sun/el/parser/AstValue.java
+++ b/impl/src/main/java/com/sun/el/parser/AstValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -217,7 +217,7 @@ public final class AstValue extends SimpleNode {
             if (ctx.isPropertyResolved()) {
                 value = targetValue;
             } else {
-                if (value != null || targetType.isPrimitive()) {
+                if (value != null || (targetType != null && targetType.isPrimitive())) {
                     value = ELSupport.coerceToType(value, targetType);
                 }
             }


### PR DESCRIPTION
There is a NullPointerException when value == null and targetType == null

Caused by: java.lang.NullPointerException
at com.sun.el.parser.AstValue.setValue(AstValue.java:247)
at com.sun.el.ValueExpressionImpl.setValue(ValueExpressionImpl.java:294)
at oracle.apps.hcm.hcmHomePage.publicUi.dc.facetedSearch.util.FacetedSearchUtility.setEL(FacetedSearchUtility.java:413)
at oracle.apps.hcm.hcmHomePage.publicUi.dc.facetedSearch.facets.SelectLinkFacet.populateDefaultModelValues(SelectLinkFacet.java:228)