### PR TITLE
Fixes #147 - Add automatic module name to the implementation jar

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -179,6 +179,7 @@
                             <Specification-Vendor>${vendorName}</Specification-Vendor>
                             <Implementation-Version>${project.version}</Implementation-Version>
                             <Implementation-Vendor>${vendorName}</Implementation-Vendor>
+                            <Automatic-Module-Name>com.sun.el</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
The name was based on the extensionName property.

Fixes #147 
Signed-off-by: Thiago Henrique Hupner <thihup@gmail.com>