### PR TITLE
static exception was causing class loader leaks

### DIFF
--- a/impl/build.xml
+++ b/impl/build.xml
@@ -31,15 +31,6 @@
         <javacc target="${dir}/ELParser.jj"
                 outputdirectory="${dir}"
                 javacchome="${javacc.home}"/>
-
-        <replaceregexp byline="true">
-          <regexp pattern="final private LookaheadSuccess"/>
-          <substitution expression="static final private LookaheadSuccess"/>
-          <fileset dir="src/main/java/com/sun/el/parser">
-            <include name="ELParser.java"/>
-          </fileset>
-        </replaceregexp>
-
     </target>
 </project>
 

--- a/impl/src/main/java/com/sun/el/parser/ELParser.java
+++ b/impl/src/main/java/com/sun/el/parser/ELParser.java
@@ -2873,7 +2873,7 @@ public class ELParser/*@bgen(jjtree)*/implements ELParserTreeConstants, ELParser
   }
 
   static private final class LookaheadSuccess extends java.lang.Error { }
-  static final private LookaheadSuccess jj_ls = new LookaheadSuccess();
+  final private LookaheadSuccess jj_ls = new LookaheadSuccess();
   private boolean jj_scan_token(int kind) {
     if (jj_scanpos == jj_lastpos) {
       jj_la--;


### PR DESCRIPTION
`LookaheadSuccess` static variable captures first application's class loader contexts that instantiates the parser,
preventing that application from ever being unloaded.

Made the variable non-static so it doesn't hang around forever